### PR TITLE
do not use unsafe_ref_capture

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,9 @@ copyright_year   = 2014
 [PkgVersion]
 [AutoPrereqs]
 
+[Prereqs]
+Devel::StackTrace = 2.00
+
 [ContributorsFromGit]
 [ReadmeFromPod]
 

--- a/t/stack.t
+++ b/t/stack.t
@@ -42,13 +42,13 @@ $ebug->break_point("t/Calc.pm", 19);
 $ebug->run;
 @trace = $ebug->stack_trace_human;
 is(scalar(@trace), 1);
-is($trace[0], '$calc->fib1(15)');
+like($trace[0], qr{^Calc::fib1\("Calc=HASH\(.*\)", 15\)});
 
 $ebug->run;
 @trace = $ebug->stack_trace_human;
 is(scalar(@trace), 2);
-is($trace[1], '$calc->fib1(15)');
-is($trace[0], '$self->fib1(14)');
+like($trace[1], qr{^Calc::fib1\("Calc=HASH\(.*\)", 15\)$});
+like($trace[0], qr{^fib1\("Calc=HASH\(.*\)", 14\)$});
 
 $ebug = Devel::ebug->new;
 $ebug->program("t/koremutake.pl");
@@ -69,7 +69,7 @@ $ebug->break_point_subroutine("String::Koremutake::integer_to_koremutake");
 $ebug->run;
 @trace = $ebug->stack_trace_human;
 is(scalar(@trace), 1);
-is($trace[0], '$koremutake->integer_to_koremutake(65535)');
+like($trace[0], qr{^String::Koremutake::integer_to_koremutake\("String::Koremutake=HASH\(.*\)", 65535\)$});
 
 $ebug = Devel::ebug->new;
 $ebug->program("t/stack.pl");
@@ -104,15 +104,15 @@ is($trace[0], 'show("orange o rama")');
 
 $ebug->run;
 @trace = $ebug->stack_trace_human;
-is($trace[0], 'show([...])');
+like($trace[0], qr{^show\("ARRAY\(.*\)"\)$});
 
 $ebug->run;
 @trace = $ebug->stack_trace_human;
-is($trace[0], 'show({...})');
+like($trace[0], qr{^show\("HASH\(.*\)"\)$});
 
 $ebug->run;
 @trace = $ebug->stack_trace_human;
-is($trace[0], 'show($koremutake)');
+like($trace[0], qr{^show\("String::Koremutake=HASH\(.*\)"\)});
 
 # use YAML; warn Dump \@trace;
 


### PR DESCRIPTION
The default output for `Devel::StackTrace` changed with version 2.00.  There is an option to turn on the old behavior using `unsafe_ref_capture`, but the documentation says that this may be unsafe.  I suspect that you could in theory be debugging from anywhere, including one of these unsafe constructs, so although the older output is a little more readable, I think not crashing is even better.  Here is some more detailed discussion:

https://rt.cpan.org/Public/Bug/Display.html?id=99811

This PR also ups the required version of `Devel::StackTrace`, so that the old unsafe behavior isn't triggered (and also so that we don't have to have to test two different types of output behavior).