### PR TITLE
remove uninitalized warning when running test suite out of git

### DIFF
--- a/lib/Devel/ebug.pm
+++ b/lib/Devel/ebug.pm
@@ -79,7 +79,7 @@ sub attach {
     );
     my $version = $response->{version};
     die "Client version $version != our version $Devel::ebug::VERSION"
-        unless $version eq $Devel::ebug::VERSION;
+        unless do { no warnings 'uninitialized'; $version eq $Devel::ebug::VERSION };
 
     $self->basic;    # get basic information for the first line
 }

--- a/t/ebug.t
+++ b/t/ebug.t
@@ -19,7 +19,7 @@ expect_run(
 
 my $version = $Devel::ebug::VERSION;
 
-expect_like(qr/Welcome to Devel::ebug $version/, 'Got welcome');
+expect_like(do{ no warnings 'uninitialized'; qr/Welcome to Devel::ebug $version/ }, 'Got welcome');
 expect_like(qr{main\(t/calc.pl#3\):\nmy \$q = 1;}, 'Got initial lines');
 expect("h", 'Commands:
 


### PR DESCRIPTION
When you run the test suite using prove out of git (without building via dzil) there are a number of uninitialized variable warnings that make debugging a pain.  This turns the warning off in two key places to keep non dzil users happy.