### PR TITLE
PRC: dzil build from git clone fails

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,8 +28,6 @@ exclude_match = Makefile.PL|cpanfile|META.json|README
 [CopyFilesFromBuild]
 copy = Makefile.PL
 copy = cpanfile
-copy = META.json
-copy = README
 
 [AutoMetaResources]
 homepage          = https://metacpan.org/release/%{dist}


### PR DESCRIPTION
When cloning the repository and running "dzil build" from the top direcotry,
the following errors occur:
```
[CopyFilesFromBuild] Cannot copy META.json from build: file does not exist
[CopyFilesFromBuild] Cannot copy META.json from build: file does not exist at C:/Strawberry/perl/vendor/lib/Moose/Meta/Method/Delegation.pm line 110.
[CopyFilesFromBuild] Cannot copy README from build: file does not exist
[CopyFilesFromBuild] Cannot copy README from build: file does not exist at C:/Strawberry/perl/vendor/lib/Moose/Meta/Method/Delegation.pm line 110.
```

The files META.json and README are generated by Dist::Zilla Basic bundle, and cannot be copied by [CopyFilesFromBuild].
Removed from [CopyFilesFromBuild].