### PR TITLE
don't throw warnings if there is -l on the shebang

### DIFF
--- a/lib/Devel/ebug/Backend.pm
+++ b/lib/Devel/ebug/Backend.pm
@@ -133,6 +133,7 @@ sub initialise {
 sub put {
   my ($res) = @_;
   my $data = unpack("h*", Dump($res));
+  local $\; # if we run under perl -l the following line would get mangled
   $context->{socket}->print($data . "\n");
 }
 

--- a/t/shebang_minus_l.pl
+++ b/t/shebang_minus_l.pl
@@ -1,0 +1,9 @@
+#!perl -l
+
+my @a = (3, 6, 2, 19, 5);
+
+for $n (sort { $a <=> $b } @a) {
+    print $n;
+}
+
+# see https://rt.cpan.org/Public/Bug/Display.html?id=29956

--- a/t/shebang_minus_l.t
+++ b/t/shebang_minus_l.t
@@ -1,0 +1,33 @@
+#!perl
+use strict;
+use warnings;
+use lib 'lib';
+use Devel::ebug;
+use Test::More;
+
+eval "use Test::Expect";
+plan skip_all => "Test::Expect required for testing ebug: $@" if $@;
+eval "use Expect::Simple";
+plan skip_all => "Expect::Simple required for testing ebug: $@" if $@;
+plan tests => 4;
+
+expect_run(
+  command => "PERL_RL=\"o=0\" $^X bin/ebug --backend \"$^X bin/ebug_backend_perl\" t/shebang_minus_l.pl",
+  prompt  => 'ebug: ',
+  quit    => 'q',
+);
+
+my $version = $Devel::ebug::VERSION;
+
+# see https://rt.cpan.org/Public/Bug/Display.html?id=29956
+# The -l option in the shebang of the program we are debugging should not cause
+# 'uninitialized' warnings in the debugger.
+
+# The tests here are only need to make sure there is some output.
+# If there are warnings in the progam, they will show up instead of the
+# empty output of the 'run to end' test, and it will fail.
+
+expect_like(do{ no warnings 'uninitialized'; qr/Welcome to Devel::ebug $version/ }, 'Got welcome');
+expect("r", qq{}, 'run to end');
+expect_quit();
+exit;


### PR DESCRIPTION
There were warnings about undefined variables when the program being debugged had the -l switch in its shebang line. This was due to the fact that -l changes $\, which added an additional \n to the serialized data that was written to the socket in the backend. The client then recieved output with two newlines, and had trouble digesting that, resulting in empty data about the basic debugging informaation like the current line (and possibly later other info).

This fixes RT 29956 (https://rt.cpan.org/Public/Bug/Display.html?id=29956) and closes #14.

This is my entry for the Pull Request Challenge 2017.